### PR TITLE
feat: returns rejected Promise instead throws Error

### DIFF
--- a/client_test.ts
+++ b/client_test.ts
@@ -1,88 +1,147 @@
-import { assertEquals, assertRejects, assertThrows } from "@std/assert";
-import { buildResponseMessage } from "./message.ts";
+import { assertEquals, assertRejects, unimplemented } from "@std/assert";
+import {
+  assertSpyCallArgs,
+  assertSpyCalls,
+  resolvesNext,
+  stub,
+} from "@std/testing/mock";
+import { Indexer } from "@lambdalisue/indexer";
+import { buildResponseMessage, type ResponseMessage } from "./message.ts";
 import { Client } from "./client.ts";
+
+type Session = ConstructorParameters<typeof Client>[0];
+
+const session: Session = {
+  send: () => unimplemented(),
+  recv: () => unimplemented(),
+};
 
 Deno.test("Client.call", async (t) => {
   await t.step("sends a request and waits for a response", async () => {
-    const receives: unknown[] = [];
-    const session = {
-      send: (message: unknown) => {
-        receives.push(message);
-      },
-      recv: (msgid: number) => {
-        return Promise.resolve(
-          buildResponseMessage(msgid, null, `response:${msgid}`),
-        );
-      },
-    };
+    using send = stub(session, "send", resolvesNext([undefined, undefined]));
+    using recv = stub(
+      session,
+      "recv",
+      (msgid: number) =>
+        Promise.resolve(buildResponseMessage(msgid, null, `response:${msgid}`)),
+    );
     const client = new Client(session);
+
     assertEquals(await client.call("foo", "bar"), "response:0");
+    assertSpyCalls(send, 1);
+    assertSpyCallArgs(send, 0, [[0, 0, "foo", ["bar"]]]);
+    assertSpyCalls(recv, 1);
+    assertSpyCallArgs(recv, 0, [0]);
+
     assertEquals(await client.call("foo", "bar"), "response:1");
-    assertEquals(receives, [
-      [0, 0, "foo", ["bar"]],
-      [0, 1, "foo", ["bar"]],
-    ]);
+    assertSpyCalls(send, 2);
+    assertSpyCallArgs(send, 1, [[0, 1, "foo", ["bar"]]]);
+    assertSpyCalls(recv, 2);
+    assertSpyCallArgs(recv, 1, [1]);
   });
 
-  await t.step("throws an error when send fails", () => {
-    const session = {
-      send: () => {
-        throw new Error("send error");
-      },
-      recv: (msgid: number) => {
-        return Promise.resolve(
-          buildResponseMessage(msgid, null, `response:${msgid}`),
-        );
-      },
-    };
+  await t.step(
+    "sends a request and waits for a response (multiple clients)",
+    async () => {
+      using send = stub(session, "send", resolvesNext([undefined, undefined]));
+      using recv = stub(
+        session,
+        "recv",
+        (msgid: number) =>
+          Promise.resolve(
+            buildResponseMessage(msgid, null, `response:${msgid}`),
+          ),
+      );
+      const indexer = new Indexer();
+      const client1 = new Client(session, { indexer });
+      const client2 = new Client(session, { indexer });
+
+      assertEquals(await client1.call("foo", "bar"), "response:0");
+      assertSpyCalls(send, 1);
+      assertSpyCallArgs(send, 0, [[0, 0, "foo", ["bar"]]]);
+      assertSpyCalls(recv, 1);
+      assertSpyCallArgs(recv, 0, [0]);
+
+      assertEquals(await client2.call("foo", "bar"), "response:1");
+      assertSpyCalls(send, 2);
+      assertSpyCallArgs(send, 1, [[0, 1, "foo", ["bar"]]]);
+      assertSpyCalls(recv, 2);
+      assertSpyCallArgs(recv, 1, [1]);
+    },
+  );
+
+  await t.step("rejects with an error when send fails", async () => {
+    using send = stub(
+      session,
+      "send",
+      resolvesNext<void>([new Error("send error")]),
+    );
+    using recv = stub(
+      session,
+      "recv",
+      (msgid: number) =>
+        Promise.resolve(buildResponseMessage(msgid, null, `response:${msgid}`)),
+    );
     const client = new Client(session);
-    assertThrows(() => client.call("foo", "bar"), Error, "send error");
+    await assertRejects(
+      async () => {
+        await client.call("foo", "bar");
+      },
+      Error,
+      "send error",
+    );
+    assertSpyCalls(send, 1);
+    assertSpyCalls(recv, 1);
   });
 
   await t.step("rejects with an error when recv fails", async () => {
-    const session = {
-      send: () => {
-        // Do NOTHING
-      },
-      recv: () => {
-        throw new Error("recv error");
-      },
-    };
+    using send = stub(session, "send", resolvesNext([undefined]));
+    using recv = stub(
+      session,
+      "recv",
+      resolvesNext<ResponseMessage>([new Error("recv error")]),
+    );
     const client = new Client(session);
-    await assertRejects(() => client.call("foo", "bar"), Error, "recv error");
+    await assertRejects(
+      async () => {
+        await client.call("foo", "bar");
+      },
+      Error,
+      "recv error",
+    );
+    assertSpyCalls(send, 1);
+    assertSpyCalls(recv, 1);
   });
 });
 
 Deno.test("Client.notify", async (t) => {
-  await t.step("sends a request", () => {
-    const receives: unknown[] = [];
-    const session = {
-      send: (message: unknown) => {
-        receives.push(message);
-      },
-      recv: () => {
-        throw new Error("should not be called");
-      },
-    };
+  await t.step("sends a request", async () => {
+    using send = stub(session, "send", resolvesNext([undefined, undefined]));
     const client = new Client(session);
-    client.notify("foo", "bar");
-    client.notify("foo", "bar");
-    assertEquals(receives, [
-      [2, "foo", ["bar"]],
-      [2, "foo", ["bar"]],
-    ]);
+
+    await client.notify("foo", "bar");
+    assertSpyCalls(send, 1);
+    assertSpyCallArgs(send, 0, [[2, "foo", ["bar"]]]);
+
+    await client.notify("foo", "bar");
+    assertSpyCalls(send, 2);
+    assertSpyCallArgs(send, 1, [[2, "foo", ["bar"]]]);
   });
 
-  await t.step("rejects with an error when send fails", () => {
-    const session = {
-      send: () => {
-        throw new Error("send error");
-      },
-      recv: () => {
-        throw new Error("should not be called");
-      },
-    };
+  await t.step("rejects with an error when send fails", async () => {
+    using send = stub(
+      session,
+      "send",
+      resolvesNext<void>([new Error("send error")]),
+    );
     const client = new Client(session);
-    assertThrows(() => client.notify("foo", "bar"), Error, "send error");
+    await assertRejects(
+      async () => {
+        await client.notify("foo", "bar");
+      },
+      Error,
+      "send error",
+    );
+    assertSpyCalls(send, 1);
   });
 });

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -32,8 +32,8 @@
     "@lambdalisue/messagepack": "jsr:@lambdalisue/messagepack@^1.0.1",
     "@lambdalisue/reservator": "jsr:@lambdalisue/reservator@^1.0.1",
     "@lambdalisue/streamtools": "jsr:@lambdalisue/streamtools@^1.0.0",
-    "@std/assert": "jsr:@std/assert@^0.221.0",
-    "@std/async": "jsr:@std/async@^0.221.0",
+    "@std/assert": "jsr:@std/assert@^0.225.1",
+    "@std/testing": "jsr:@std/testing@^0.224.0",
     "@lambdalisue/messagepack-rpc": "./mod.ts"
   }
 }


### PR DESCRIPTION
- A function that returns a Promise should return a rejected Promise instead of throwing an exception.
- `Client#notify()` and `Session#send()` should return a Promise as it may cause an unhandled-rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced asynchronous message handling in the `Client` class with `async/await`.
  - Added new error handling and rejection conditions in the `Session` class for more robust operations.

- **Bug Fixes**
  - Updated error handling in both `Client` and `Session` classes to ensure stability and reliability.

- **Tests**
  - Expanded testing for the `Client` and `Session` classes, including new test cases and using stubs for method simulation.

- **Documentation**
  - Updated configuration dependencies for better compatibility and performance.

- **Refactor**
  - Transitioned several methods in `Client` and `Session` to return promises, supporting better error management and asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->